### PR TITLE
fix: improve task stage assignment and reordering logic

### DIFF
--- a/task_manager/tasks/models.py
+++ b/task_manager/tasks/models.py
@@ -301,14 +301,15 @@ class Task(models.Model):
         Args:
             new_stage_id: The ID of the stage to move the task to
         """
-        old_stage_id = self.stage.id
-        self.stage.id = new_stage_id
+        old_stage = self.stage
+        new_stage = Stage.objects.get(id=new_stage_id)
+        self.stage = new_stage
 
         self.save()
 
-        if old_stage_id:
-            reorder_tasks_in_stage(old_stage_id)
-        reorder_tasks_in_stage(new_stage_id)
+        if old_stage:
+            reorder_tasks_in_stage(old_stage)
+        reorder_tasks_in_stage(new_stage)
 
     def reorder_within_stage(self, new_order: int) -> None:
         """

--- a/task_manager/tasks/services.py
+++ b/task_manager/tasks/services.py
@@ -286,7 +286,7 @@ def _process_order_change(
 ) -> None:
     """Process order change for a task."""
     if new_stage_id is not None:
-        task.stage.id = new_stage_id
+        task.stage_id = new_stage_id
         task.save(update_fields=['stage_id'])
 
     if new_order is not None:
@@ -419,9 +419,9 @@ def reorder_stages(old_stage: Stage, new_stage: Stage) -> None:
         new_stage: The new stage object
     """
     if old_stage:
-        reorder_tasks_in_stage(old_stage.pk)
+        reorder_tasks_in_stage(old_stage)
     if new_stage:
-        reorder_tasks_in_stage(new_stage.pk)
+        reorder_tasks_in_stage(new_stage)
 
 
 def process_bulk_task_updates(


### PR DESCRIPTION
- Fix Task.move_to_stage() to properly assign Stage objects instead of IDs
- Update reorder_tasks_in_stage() calls to pass Stage objects instead of IDs
- Fix stage assignment in _process_order_change() to use stage_id field
- Improve consistency in stage handling across task operations