### PR TITLE
feat: add Django REST Knox authentication API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "djangorestframework>=3.16.1",
     "markdown>=3.9",
     "django-rest-knox>=5.0.2",
+    "django-cors-headers>=4.3.1",
 ]
 
 [project.optional-dependencies]

--- a/task_manager/settings.py
+++ b/task_manager/settings.py
@@ -331,7 +331,8 @@ REST_KNOX = {
 }
 
 # CORS settings
-CORS_ALLOW_ALL_ORIGINS = True
+if DEBUG:
+    CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_CREDENTIALS = True
 
 # Разрешенные заголовки

--- a/task_manager/settings.py
+++ b/task_manager/settings.py
@@ -62,12 +62,14 @@ INSTALLED_APPS = (
     'django_filters',
     'django_htmx',
     'knox',
+    'corsheaders',
 )
 
 if DEBUG:
     INSTALLED_APPS = (*INSTALLED_APPS, 'django_extensions')
 
 MIDDLEWARE = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -327,3 +329,30 @@ REST_KNOX = {
     'EXPIRY_DATETIME_FORMAT': api_settings.DATETIME_FORMAT,
     'AUTO_REFRESH': True,
 }
+
+# CORS settings
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_CREDENTIALS = True
+
+# Разрешенные заголовки
+CORS_ALLOW_HEADERS = [
+    'accept',
+    'accept-encoding',
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'x-csrftoken',
+    'x-requested-with',
+]
+
+# Разрешенные методы
+CORS_ALLOW_METHODS = [
+    'DELETE',
+    'GET',
+    'OPTIONS',
+    'PATCH',
+    'POST',
+    'PUT',
+]

--- a/task_manager/users/apis.py
+++ b/task_manager/users/apis.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth import login, logout
+from django.http import JsonResponse
 from knox.views import LoginView as KnoxLoginView
 from knox.views import LogoutView as KnoxLogoutView
 from rest_framework import permissions, status
@@ -21,7 +22,21 @@ class LoginView(KnoxLoginView):
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
         login(request, user)
-        return super().post(request, format=None)
+        response = super().post(request, format=None)
+
+        # Добавляем CORS заголовки
+        response['Access-Control-Allow-Origin'] = '*'
+        response['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
+        response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+
+        return response
+
+    def options(self, request, *args, **kwargs):
+        response = JsonResponse({})
+        response['Access-Control-Allow-Origin'] = '*'
+        response['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
+        response['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+        return response
 
 
 class LogoutView(KnoxLogoutView):
@@ -32,7 +47,7 @@ class LogoutView(KnoxLogoutView):
 
         response = Response(
             {'message': 'Вы успешно вышли из системы'},
-            status=status.HTTP_200_OK
+            status=status.HTTP_200_OK,
         )
         response['Content-Type'] = 'application/json; charset=utf-8'
         return response
@@ -50,8 +65,7 @@ class UserProfileView(APIView):
 
         serializer = UserSerializer(request.user)
         response = Response(
-            {'user': serializer.data},
-            status=status.HTTP_200_OK
+            {'user': serializer.data}, status=status.HTTP_200_OK
         )
         response['Content-Type'] = 'application/json; charset=utf-8'
         return response

--- a/uv.lock
+++ b/uv.lock
@@ -516,6 +516,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/8e/6225441edcfe179bf4861e9e67489e33375e0b66316c8d7b9edaae863d37/django_cors_headers-4.8.0.tar.gz", hash = "sha256:0a12a2efcd59a3cea741e44db8ab589e929949de5bc4cdf35a29c6ae77297686", size = 21425, upload-time = "2025-09-08T15:58:05.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/b3/29ef49d6ff7800f323f3d98cde7777b3cfdda133de8feea84cffafea4578/django_cors_headers-4.8.0-py3-none-any.whl", hash = "sha256:3b883f4c6d07848673218456a5e070d8ab51f97341c1f27d0242ca167e7272ab", size = 12804, upload-time = "2025-09-08T15:58:03.882Z" },
+]
+
+[[package]]
 name = "django-crispy-forms"
 version = "2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1436,6 +1449,7 @@ dependencies = [
     { name = "dj-database-url" },
     { name = "django" },
     { name = "django-celery-beat" },
+    { name = "django-cors-headers" },
     { name = "django-crispy-forms" },
     { name = "django-extensions" },
     { name = "django-filter" },
@@ -1483,6 +1497,7 @@ requires-dist = [
     { name = "dj-database-url", specifier = ">=0.5.0" },
     { name = "django", specifier = ">=5.1.2" },
     { name = "django-celery-beat", specifier = ">=2.5.0" },
+    { name = "django-cors-headers", specifier = ">=4.3.1" },
     { name = "django-crispy-forms", specifier = ">=2.3" },
     { name = "django-extensions", specifier = ">=4.1" },
     { name = "django-filter", specifier = ">=24.3" },


### PR DESCRIPTION
- Add django-cors-headers for CORS support
- Configure CORS settings for PWA integration
- Add LoginView and LogoutView with CORS headers
- Add ProfileView for user data retrieval
- Update API URLs for authentication endpoints
- Add manual CORS headers for OPTIONS requests
- Configure CORS_ALLOW_ALL_ORIGINS for development
- Add CORS_ALLOW_HEADERS and CORS_ALLOW_METHODS settings