### PR TITLE
fix: check rolldown native binary instead of rollup in frontend image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ RUN npm config set strict-ssl false
 COPY package.json package-lock.json ./
 RUN npm cache clean --force \
   && npm ci --include=optional \
-  && node -e "require('@rollup/rollup-linux-x64-gnu'); console.log('rollup native ok')"
+  && node -e "require('@rolldown/binding-linux-x64-gnu'); console.log('rolldown native ok')"
 
 COPY . ./
 


### PR DESCRIPTION
## Проблема

Сборка docker-образов на теге `v1.2.8` упала на этапе frontend:

```
[frontend 6/8] RUN npm ci --include=optional
  && node -e "require('@rollup/rollup-linux-x64-gnu'); ..."
Error: Cannot find module '@rollup/rollup-linux-x64-gnu'  (MODULE_NOT_FOUND)
target frontend: failed to solve ... exit code: 1
```

## Причина

В составе #30 (bump esbuild/vite/@vitejs/plugin-react) обновился **vite до 8.0.16**. Vite 8 сменил бандлер с **rollup на rolldown**, поэтому `@rollup/rollup-linux-x64-gnu` больше нет в дереве зависимостей (проверено: в `frontend/package-lock.json` на main нет ни `rollup`, ни `@rollup/rollup-*`).

Smoke-проверка в `frontend/Dockerfile` всё ещё требовала нативный модуль rollup → `MODULE_NOT_FOUND` → падение сборки образа. Поскольку docker-build триггерится только тегом `v*`, регрессия проявилась лишь при релизе 1.2.8, а не на обычном CI.

## Исправление

Заменил проверку на актуальный нативный бинарь rolldown — `@rolldown/binding-linux-x64-gnu` (он есть в lock как optional-зависимость vite 8, версия 1.0.3). Smoke-тест сохранён, просто указывает на правильный пакет.

## Проверка

Локальная сборка образа frontend проходит:

```
#10 ... rolldown native ok
#13 exporting to image ... DONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)