### PR TITLE
ci: make release docker build reliable and manually re-runnable

### DIFF
--- a/.github/workflows/ci-docker-compose.yml
+++ b/.github/workflows/ci-docker-compose.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to (re)build images for, e.g. v1.2.9'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,15 +18,21 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    if: >-
+      (github.event_name == 'push' && github.ref_type == 'tag'
+        && startsWith(github.ref_name, 'v'))
+      || (github.event_name == 'workflow_dispatch'
+        && startsWith(inputs.tag, 'v'))
     env:
       DOCKER_BUILDKIT: "1"
       COMPOSE_DOCKER_CLI_BUILD: "1"
       BUILDKIT_PROGRESS: plain
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -30,6 +42,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve checked-out commit SHA
+        id: sha
+        run: echo "value=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -45,20 +61,19 @@ jobs:
       - name: Build all services via docker compose
         env:
           IMAGE_REGISTRY: ghcr.io/turtleold/task_manager
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ steps.sha.outputs.value }}
         run: docker compose build --pull backend celery frontend
 
       - name: Push images to GHCR
         env:
           IMAGE_REGISTRY: ghcr.io/turtleold/task_manager
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ steps.sha.outputs.value }}
         run: docker compose push backend celery frontend
 
       - name: Tag and push release aliases
         env:
           IMAGE_REGISTRY: ghcr.io/turtleold/task_manager
-          SHA_TAG: ${{ github.sha }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          SHA_TAG: ${{ steps.sha.outputs.value }}
         run: |
           set -euo pipefail
           for img in backend celery frontend; do

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,8 +14,39 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # A PAT (not GITHUB_TOKEN) is required: tags pushed with GITHUB_TOKEN do
+      # not trigger other workflows, so the v* tag would never start the docker
+      # build. Fail fast here instead of producing a silently un-built release.
+      - name: Ensure release token is configured
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "RELEASE_PLEASE_TOKEN secret is not set; release tags would" \
+                 "not trigger the docker build." >&2
+            exit 1
+          fi
+
       - uses: googleapis/release-please-action@v5.0.0
+        id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Report release outcome
+        env:
+          OUTPUTS: ${{ toJSON(steps.release.outputs) }}
+        run: |
+          created=$(echo "$OUTPUTS" | jq -r \
+            '[to_entries[] | select(.key | endswith("release_created"))
+              | .value] | any(. == "true")')
+          if [ "$created" = "true" ]; then
+            tags=$(echo "$OUTPUTS" | jq -r \
+              'to_entries[] | select(.key | endswith("tag_name")) | .value')
+            echo "Release created; tags pushed: $tags"
+            echo "Docker build starts from the tag push event."
+          else
+            echo "No release created on this run (release PR pending or" \
+                 "no releasable changes)."
+          fi


### PR DESCRIPTION
## Проблема

Сборка docker-образов запускалась только по событию push тега `v*` (workflow `ci-docker-compose.yml`), а тег создавал release-please в **отдельном** workflow. Связь «мердж release-PR → сборка образов» была косвенной и хрупкой:

- На релизе **1.2.8** release-please слил release-PR, но прервался с `There are untagged, merged release PRs outstanding - aborting` и **тег `v1.2.8` не создал**. В результате docker-build молча не запустился, и образы не пересобрались — притом что в логах release-please был `success`.
- Дополнительный риск: тег, запушенный под `GITHUB_TOKEN`, по правилам GitHub **не триггерит** другие workflow, то есть даже при созданном теге сборка могла не стартовать.

## Что меняется

Делаем релизный процесс production-ready, сохранив тег-триггер, но устранив тихие сбои:

**`release-please.yml`**
- Требуем `RELEASE_PLEASE_TOKEN` (PAT) и **падаем сразу**, если он не задан — иначе тег под `GITHUB_TOKEN` не запустит сборку. Лучше явная ошибка, чем релиз без образов.
- Убран фолбэк `|| secrets.GITHUB_TOKEN` (он и приводил к «тег есть, сборки нет»).
- Добавлен шаг **Report release outcome**: в лог пишется, создан ли релиз и какие теги запушены — пропавший релиз становится видимым, а не молчит.

**`ci-docker-compose.yml`**
- Добавлен **`workflow_dispatch`** с input `tag` — образы для существующего релизного тега можно **пересобрать вручную**, если тег-событие было пропущено (аварийный retry без перетегирования).
- `if` и `checkout ref` учитывают оба триггера (tag push / ручной запуск).
- Образы тегируются по **реально зачекаученному** commit SHA (`git rev-parse HEAD`), а не по `github.sha` триггера — корректно и для ручного запуска по тегу.

## Безопасность

Все динамические значения (`inputs.tag`, release outputs) пробрасываются через `env:` и не инлайнятся в shell; `inputs.tag` валидируется (`startsWith('v')`). Источник тега — release-please (доверенный), не пользовательский текст.

## Проверка

- YAML обоих файлов валиден.
- `actionlint` (через docker) — **без замечаний** (exit 0): выражения, контексты и shell в `run:` корректны.

## Примечание по выкатке

Этот PR **не** чинит уже застрявший тег `v1.2.8` (его сборка всё равно красная из-за устаревшей проверки rollup — это отдельный #37). Корректный путь: смержить #37, выпустить патч **1.2.9**, и новый релиз соберётся уже по исправленному процессу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)