### PR TITLE
fix: пропадающий push при перемещении карточки из-за таймаутов redis

### DIFF
--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -147,6 +147,7 @@ _REDIS_SOCKET_KEEPALIVE_OPTIONS = {
     socket.TCP_KEEPCNT: 5,
 }
 REDIS_HEALTH_CHECK_INTERVAL = int(os.getenv("REDIS_HEALTH_CHECK_INTERVAL", "30"))
+REDIS_SOCKET_TIMEOUT = int(os.getenv("REDIS_SOCKET_TIMEOUT", "20"))
 
 CHANNEL_LAYERS = {
     "default": {
@@ -157,6 +158,8 @@ CHANNEL_LAYERS = {
                     "address": REDIS_URL,
                     "socket_keepalive": True,
                     "socket_keepalive_options": _REDIS_SOCKET_KEEPALIVE_OPTIONS,
+                    "socket_timeout": REDIS_SOCKET_TIMEOUT,
+                    "socket_connect_timeout": REDIS_SOCKET_TIMEOUT,
                     "health_check_interval": REDIS_HEALTH_CHECK_INTERVAL,
                 }
             ],

--- a/frontend/src/pages/board/BoardPage.tsx
+++ b/frontend/src/pages/board/BoardPage.tsx
@@ -100,6 +100,10 @@ export function BoardPage({ user }: BoardPageProps) {
   useBoardWebSocket({
     boardId,
     token: wsToken,
+    onOpen: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.cards(boardId) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.columns(boardId) })
+    },
     onEvent: (event: BoardEvent) => {
       if (event.type === 'card.created') {
         queryClient.setQueryData<Card[]>(queryKeys.cards(boardId), (prev) => {

--- a/frontend/src/useBoardWebSocket.ts
+++ b/frontend/src/useBoardWebSocket.ts
@@ -30,14 +30,17 @@ interface Options {
   boardId: number
   token: string | null
   onEvent: (event: BoardEvent) => void
+  onOpen?: () => void
 }
 
 const RECONNECT_DELAY_MS = 3000
 
-export function useBoardWebSocket({ boardId, token, onEvent }: Options) {
+export function useBoardWebSocket({ boardId, token, onEvent, onOpen }: Options) {
   const wsRef = useRef<WebSocket | null>(null)
   const onEventRef = useRef(onEvent)
   onEventRef.current = onEvent
+  const onOpenRef = useRef(onOpen)
+  onOpenRef.current = onOpen
 
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const unmountedRef = useRef(false)
@@ -52,6 +55,10 @@ export function useBoardWebSocket({ boardId, token, onEvent }: Options) {
       const url = `${getWsBase()}/ws/boards/${boardId}/?token=${token}`
       const ws = new WebSocket(url)
       wsRef.current = ws
+
+      ws.onopen = () => {
+        onOpenRef.current?.()
+      }
 
       ws.onmessage = (e) => {
         try {


### PR DESCRIPTION
## Описание

На проде при перемещении карточки иногда переставал приходить realtime push по WebSocket, хотя сам запрос перемещения (`POST /cards/<id>/move/`) отрабатывал успешно (200 OK). В логах backend в этот момент фиксировалась ошибка:

```
redis.exceptions.TimeoutError: Timeout reading from redis:6379
```

### Причина

Хост, на котором развёрнут прод, разделяется примерно с полусотней других контейнеров (immich, komodo, homemail и т.д.) и периодически испытывает кратковременные просадки CPU/IO. Из-за этого event loop backend'а иногда не успевает вовремя вычитать сокет Redis — Redis при этом жив и не показывает ошибок, проблема чисто в таймингах на стороне клиента.

Усугубляло ситуацию два момента:

1. В конфигурации `CHANNEL_LAYERS` не был задан `socket_timeout`/`socket_connect_timeout`, из-за чего поведение при заминке было непредсказуемым, а не быстрым и контролируемым разрывом с последующим переподключением.
2. После разрыва и переподключения WebSocket на фронтенде состояние доски не обновлялось — переподключение просто возобновляло приём новых событий, а те, что были отправлены сервером во время разрыва, терялись без возможности восстановления. Это и объясняет ощущение "push не пришёл": карточка на сервере переместилась, но клиент об этом никогда не узнавал.

### Изменения

- `backend/src/config/settings.py`: заданы явные `socket_timeout`/`socket_connect_timeout` (20s, настраивается через `REDIS_SOCKET_TIMEOUT`) для redis-соединения channel layer, чтобы временная заминка хоста приводила к быстрому и предсказуемому разрыву соединения вместо неопределённого зависания.
- `frontend/src/useBoardWebSocket.ts`: хук получил колбэк `onOpen`, вызываемый при каждом успешном (пере)подключении.
- `frontend/src/pages/board/BoardPage.tsx`: по `onOpen` инвалидируются запросы cards/columns, чтобы после любого разрыва соединения доска подтягивала актуальное состояние и не теряла пропущенные изменения.

### Что не входит в этот PR

Корневая причина — общая нагрузка на прод-хосте — этим PR не устраняется, только последствия для пользователя (потеря push) сглажены на уровне протокола. Также отдельно (вне кода) рекомендовано включить `vm.overcommit_memory=1` на хосте — Redis явно предупреждает об этом в логах.

## Test plan

- [x] `pytest tests/test_card_move.py tests/test_broadcast.py` — зелёные
- [x] `tsc --noEmit` на фронтенде — без ошибок
- [ ] Проверить на проде, что после включения фикса частота "пропавших" push снизилась